### PR TITLE
#14 - Display meal preference and dietary requirements only if guest attending 

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -24,4 +24,9 @@ $(document).ready(function() {
     $('#modal-window').removeClass('hidden');
   });
 
+    $("#rsvp_attending").change(function(){
+        if($("#rsvp_attending").val() == "Yes"){
+          $('.optional-elements').removeClass('hidden');
+        }
+    });
 });

--- a/app/models/rsvp.rb
+++ b/app/models/rsvp.rb
@@ -1,6 +1,7 @@
 class Rsvp < ActiveRecord::Base
   belongs_to :guest
-  validates_presence_of :attending, :meal_preference
+  validates_presence_of :attending
   validates_presence_of :guest_id, :message => "not registered to attend the wedding"
+  validates_presence_of :meal_preference, :if => 'attending == "Yes"'
   attr_accessor :full_name
 end

--- a/app/views/rsvps/_form.html.erb
+++ b/app/views/rsvps/_form.html.erb
@@ -2,10 +2,11 @@
   <%= bootstrap_form_for(@rsvp, layout: :horizontal)  do |f| %>
     <%= @rsvp.errors.full_messages.first if @rsvp.errors.any? %>
     <%= f.text_field :full_name, placeholder: 'Enter full name', class: 'form-control required' %>
-    <%= f.select :attending, [ 'Yes', 'No' ], :prompt => 'Are you attending?' %>
-    <%= f.select :meal_preference, [ 'Chicken', 'Steak', 'Falafel, Not attending' ], :prompt => 'Select Preference' %>
-    <%= f.text_field :dietary_requirements, placeholder: 'Enter dietary requirements', class: 'form-control required' %>
-
+    <%= f.select :attending, [ 'Yes', 'No' ], :prompt => 'Are you attending?', class: 'form-control required' %>
+    <div class='optional-elements hidden'>
+      <%= f.select :meal_preference, [ 'Chicken', 'Steak', 'Falafel' ], :prompt => 'Select Preference', class: 'form-control' %>
+      <%= f.text_field :dietary_requirements, placeholder: 'Enter dietary requirements', class: 'form-control' %>
+    </div>
     <div class='level-header'>
       <%= button_tag(type: 'submit', class: "btn gift-button command-button save-button", data: {disable_with: "<i class='fa fa-spinner fa-spin'></i> Saving..."}) do %>
         <i class="fa fa-save"></i> Save


### PR DESCRIPTION
This pull request resolves #14.  It only displays meal preferences and dietary requirements only if a guest is attending. 

It only validates presence of meal preference for RSVP when attending is set to yes
